### PR TITLE
Lock down NPM dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,27 +7,27 @@
     "test": "test"
   },
   "dependencies": {
-    "async": "~0.2.9",
-    "lodash": "~2.4.1",
-    "fs-extra": "~0.8.1",
-    "merge-defaults": "~0.1.0",
-    "reportback": "~0.1.8",
-    "sails-generate-new": "~0.10.0",
-    "sails-generate-backend": "~0.11.0",
-    "sails-generate-frontend": "~0.10.0",
-    "sails-generate-gruntfile": "~0.10.0",
-    "sails-generate-api": "~0.10.0",
-    "sails-generate-model": "~0.10.9",
-    "sails-generate-controller": "~0.10.7",
-    "sails-generate-views": "~0.10.0",
-    "sails-generate-adapter": "~0.10.0",
-    "sails-generate-generator": "~0.10.0",
-    "sails-generate-views-jade": "~0.10.0"
+    "async": "0.7.0",
+    "lodash": "2.4.1",
+    "fs-extra": "0.8.1",
+    "merge-defaults": "0.1.4",
+    "reportback": "0.1.8",
+    "sails-generate-new": "0.10.18",
+    "sails-generate-backend": "0.11.3",
+    "sails-generate-frontend": "0.10.20",
+    "sails-generate-gruntfile": "0.10.10",
+    "sails-generate-api": "0.10.0",
+    "sails-generate-model": "0.10.9",
+    "sails-generate-controller": "0.10.7",
+    "sails-generate-views": "0.10.4",
+    "sails-generate-adapter": "0.10.4",
+    "sails-generate-generator": "0.10.11",
+    "sails-generate-views-jade": "0.10.3"
   },
   "devDependencies": {
-    "mocha": "~1.17.0",
-    "checksum": "~0.1.1",
-    "root-require": "~0.3.1"
+    "mocha": "2",
+    "checksum": "0.1.1",
+    "root-require": "0.3.1"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
Used the versions we have installed in the Shyp API package. We can probably
remove some of these, but doesn't seem worth the effort.
